### PR TITLE
pgsh create <name>

### DIFF
--- a/src/cmd/clone.js
+++ b/src/cmd/clone.js
@@ -16,6 +16,11 @@ exports.handler = async ({ target }) => {
   const current = db.thisDb();
   if (target === current) {
     console.log(`Cannot clone to ${target}; that's the current database!`);
+    return process.exit(1);
+  }
+
+  if (await db.isValidDatabase(target)) {
+    console.error(`Cannot clone to ${target}; that database already exists!`);
     return process.exit(2);
   }
 

--- a/src/cmd/create.js
+++ b/src/cmd/create.js
@@ -1,0 +1,79 @@
+const c = require('ansi-colors');
+const { prompt } = require('enquirer');
+const config = require('../config');
+
+exports.command = 'create <name>';
+exports.desc = 'creates a new database as name, then switches to it';
+
+exports.builder = yargs => yargs
+  .positional('name', {
+    describe: 'the name to give the new database',
+    type: 'string',
+  })
+  .option('m', {
+    alias: 'migrate',
+    type: 'boolean',
+    describe: 'also migrate the new database to the current version',
+    default: undefined,
+  });
+
+exports.handler = async ({ name, migrate, ...yargs }) => {
+  const db = require('../db');
+
+  const current = db.thisDb();
+  if (name === current) {
+    console.log(`Cannot create ${name}; that's the current database!`);
+    return process.exit(1);
+  }
+
+  if (await db.isValidDatabase(name)) {
+    console.error(`Cannot create ${name}; that database already exists!`);
+    return process.exit(2);
+  }
+
+  console.log(`Going to create ${name}...`);
+  const knex = db.connectAsSuper();
+  await knex.raw(`
+    create database ${name}
+    template ${config.template || 'template1'}
+  `);
+  db.switchTo(name);
+  console.log(`Done! Switched to ${name}.`);
+
+  let shouldMigrate = migrate;
+  if (config.migrations && shouldMigrate === undefined) {
+    shouldMigrate = (await prompt({
+      type: 'toggle',
+      name: 'migrate',
+      message: 'Migrate this database to the latest version?',
+    })).migrate;
+  }
+
+  if (shouldMigrate) {
+    // TODO: DRY "up"
+    // TODO: use middleware for printLatest
+    const printLatest = require('../util/print-latest-migration')(yargs);
+    try {
+      const [batch, filenames] = await knex.migrate.latest();
+      if (filenames.length > 0) {
+        console.log(`Migration batch #${batch} applied!`);
+        filenames.forEach(filename =>
+          console.log(`↑ ${c.yellowBright(filename)}`));
+        console.log();
+      }
+      await printLatest(knex);
+    } catch (err) {
+      console.error('Knex migration failed (see above).');
+      console.log(
+        `Switching back to ${c.yellowBright(current)}`
+        + ' and dropping the new database...',
+      );
+      db.switchTo(current);
+      await knex.raw(`drop database ${name};`);
+      console.log('Done.');
+      process.exit(1);
+    }
+  }
+
+  return process.exit(0);
+};

--- a/src/cmd/knex/up.js
+++ b/src/cmd/knex/up.js
@@ -1,5 +1,4 @@
 const c = require('ansi-colors');
-const config = require('../../config');
 
 exports.command = 'up';
 exports.desc = '(knex) migrates the current database to the latest version found in your migration directory';
@@ -10,17 +9,8 @@ exports.handler = async (yargs) => {
   const db = require('../../db');
   const printLatest = require('../../util/print-latest-migration')(yargs); // TODO: use middleware
 
-  const schema = config.migrations.schema || 'public';
-  const table = config.migrations.table || 'knex_migrations';
-  const migrations = { schemaName: schema, tableName: table };
-
-  const migrationsPath = db.getMigrationsPath();
-  if (migrationsPath) {
-    migrations.directory = migrationsPath;
-  }
-
   try {
-    const knex = db.connect({ migrations });
+    const knex = db.connect();
     const [batch, filenames] = await knex.migrate.latest();
     if (filenames.length > 0) {
       console.log(`Migration batch #${batch} applied!`);

--- a/src/cmd/list.js
+++ b/src/cmd/list.js
@@ -53,7 +53,7 @@ exports.handler = async (yargs) => {
     async (name) => {
       let migration = [];
       if (config.migrations && verbose) {
-        const knex = db.connectAsSuper({}, db.thisUrl(name));
+        const knex = db.connectAsSuper(db.thisUrl(name));
         migration = await migrationOutput(knex, name === current);
       }
 


### PR DESCRIPTION
* make sure clone target doesn't exist
* add the `pgsh create <name>` command, which optionally applies all migrations too
* add `migrations` options to every Knex instance created, rather than just migration ones (doesn't hurt non-migration queries)

Closes #22 