### PR TITLE
Feat/init choose db

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bluebird": "^3.5.3",
     "cli-table": "^0.3.1",
     "debug": "^4.1.1",
+    "deep-equal": "^1.0.1",
     "dotenv": "^6.2.0",
     "enquirer": "^2.3.0",
     "find-config": "^1.0.0",

--- a/src/cmd/create.js
+++ b/src/cmd/create.js
@@ -1,7 +1,4 @@
 const c = require('ansi-colors');
-const { prompt } = require('enquirer');
-const config = require('../config');
-const readMigrations = require('../util/read-migrations');
 
 exports.command = 'create <name>';
 exports.desc = 'creates a new database as name, then switches to it';
@@ -19,7 +16,8 @@ exports.builder = yargs => yargs
   });
 
 exports.handler = async ({ name, migrate, ...yargs }) => {
-  const db = require('../db');
+  const db = require('../db')();
+  const create = require('../task/create')(db);
 
   const current = db.thisDb();
   if (name === current) {
@@ -33,52 +31,16 @@ exports.handler = async ({ name, migrate, ...yargs }) => {
   }
 
   console.log(`Going to create ${name}...`);
-  const knex = db.connectAsSuper(db.thisUrl(config.fallback_database));
-  await knex.raw(`
-    create database "${name}"
-    template ${config.template || 'template1'}
-  `);
-  db.switchTo(name);
-  console.log(`Done! Switched to ${name}.`);
+  try {
+    await create(name, {
+      migrate,
+      yargs,
+      switch: true,
+    });
 
-  let shouldMigrate = migrate;
-  if (config.migrations && shouldMigrate === undefined) {
-    // only show the prompt if we have some migrations in the folder.
-    const migrationFiles = readMigrations(db.getMigrationsPath());
-    if (migrationFiles.length > 0) {
-      shouldMigrate = (await prompt({
-        type: 'toggle',
-        name: 'migrate',
-        message: 'Migrate this database to the latest version?',
-      })).migrate;
-    }
+    return process.exit(0);
+  } catch (err) {
+    console.error(`could not create: ${c.redBright(err.message)}`);
+    return process.exit(3);
   }
-
-  if (config.migrations && shouldMigrate) {
-    // TODO: DRY "up"
-    // TODO: use middleware for printLatest
-    const printLatest = require('../util/print-latest-migration')(yargs);
-    try {
-      const [batch, filenames] = await knex.migrate.latest();
-      if (filenames.length > 0) {
-        console.log(`Migration batch #${batch} applied!`);
-        filenames.forEach(filename =>
-          console.log(`↑ ${c.yellowBright(filename)}`));
-        console.log();
-      }
-      await printLatest(knex);
-    } catch (err) {
-      console.error('Knex migration failed (see above).');
-      console.log(
-        `Switching back to ${c.yellowBright(current)}`
-        + ' and dropping the new database...',
-      );
-      db.switchTo(current);
-      await knex.raw(`drop database "${name}"`);
-      console.log('Done.');
-      process.exit(1);
-    }
-  }
-
-  return process.exit(0);
 };

--- a/src/cmd/current.js
+++ b/src/cmd/current.js
@@ -4,7 +4,7 @@ exports.desc = 'prints the name of the database that your connection string refe
 exports.builder = {};
 
 exports.handler = () => {
-  const db = require('../db');
+  const db = require('../db')();
   console.log(db.thisDb());
   process.exit(0);
 };

--- a/src/cmd/destroy.js
+++ b/src/cmd/destroy.js
@@ -13,7 +13,7 @@ exports.builder = yargs =>
     });
 
 exports.handler = async ({ target }) => {
-  const db = require('../db');
+  const db = require('../db')();
 
   const current = db.thisDb();
   if (target === current) {
@@ -42,7 +42,7 @@ exports.handler = async ({ target }) => {
   }
 
   console.log(`Dropping ${target}...`);
-  const knex = db.connectAsSuper(db.thisUrl(config.fallback_database));
+  const knex = db.connectAsSuper(db.fallbackUrl());
   await knex.raw(`drop database "${target}"`);
   return process.exit(0);
 };

--- a/src/cmd/dump.js
+++ b/src/cmd/dump.js
@@ -12,7 +12,7 @@ exports.builder = yargs =>
     });
 
 exports.handler = async ({ target }) => {
-  const db = require('../db');
+  const db = require('../db')();
   const name = target || db.thisDb();
 
   if (!(await db.isValidDatabase(name))) {

--- a/src/cmd/knex/down.js
+++ b/src/cmd/knex/down.js
@@ -13,7 +13,7 @@ exports.builder = yargs =>
     });
 
 exports.handler = async (yargs) => {
-  const db = require('../../db');
+  const db = require('../../db')();
   const createKnexfile = require('../../util/create-knexfile');
   const printLatest = require('../../util/print-latest-migration')(yargs); // TODO: use middleware
 

--- a/src/cmd/knex/force-down.js
+++ b/src/cmd/knex/force-down.js
@@ -16,7 +16,7 @@ exports.builder = yargs =>
     });
 
 exports.handler = async (yargs) => {
-  const db = require('../../db');
+  const db = require('../../db')();
   const { ver: version, iso } = yargs;
   const printLatest = require('../../util/print-latest-migration')(yargs); // TODO: use middleware
   const timestamp = raw => (iso

--- a/src/cmd/knex/force-up.js
+++ b/src/cmd/knex/force-up.js
@@ -10,7 +10,7 @@ exports.desc = 're-writes the knex migrations table entirely based on your migra
 exports.builder = {};
 
 exports.handler = async (yargs) => {
-  const db = require('../../db');
+  const db = require('../../db')();
   const printLatest = require('../../util/print-latest-migration')(yargs); // TODO: use middleware
 
   const schema = config.migrations.schema || 'public';

--- a/src/cmd/knex/up.js
+++ b/src/cmd/knex/up.js
@@ -6,7 +6,7 @@ exports.desc = '(knex) migrates the current database to the latest version found
 exports.builder = yargs => yargs;
 
 exports.handler = async (yargs) => {
-  const db = require('../../db');
+  const db = require('../../db')();
   const printLatest = require('../../util/print-latest-migration')(yargs); // TODO: use middleware
 
   try {

--- a/src/cmd/list.js
+++ b/src/cmd/list.js
@@ -39,7 +39,7 @@ const migrationOutput = async (knex, isPrimary) => {
 };
 
 exports.handler = async (yargs) => {
-  const db = require('../db');
+  const db = require('../db')();
   const { prefix, verbose } = yargs;
 
   try {

--- a/src/cmd/psql.js
+++ b/src/cmd/psql.js
@@ -12,7 +12,7 @@ exports.builder = yargs =>
     });
 
 exports.handler = ({ name }) => {
-  const db = require('../db');
+  const db = require('../db')();
   const p = spawn('psql', ['-d', name || db.thisDb()], {
     stdio: 'inherit',
     env: {

--- a/src/cmd/restore.js
+++ b/src/cmd/restore.js
@@ -12,7 +12,7 @@ exports.builder = yargs =>
     });
 
 exports.handler = async ({ target }) => {
-  const db = require('../db');
+  const db = require('../db')();
 
   if (await db.isValidDatabase(target)) {
     console.error(`Cannot restore to ${target}; that database already exists!`);

--- a/src/cmd/switch.js
+++ b/src/cmd/switch.js
@@ -14,7 +14,7 @@ exports.builder = yargs => yargs
   });
 
 exports.handler = async ({ target, force }) => {
-  const db = require('../db');
+  const db = require('../db')();
 
   if (!force && !(await db.isValidDatabase(target))) {
     console.error(`${target} is not a valid database.`);

--- a/src/cmd/switch.js
+++ b/src/cmd/switch.js
@@ -5,12 +5,18 @@ exports.builder = yargs => yargs
   .positional('target', {
     describe: 'the database to switch to',
     type: 'string',
+  })
+  .option('f', {
+    alias: 'force',
+    type: 'boolean',
+    describe: 'switch even if the target does not exist',
+    default: false,
   });
 
-exports.handler = async ({ target }) => {
+exports.handler = async ({ target, force }) => {
   const db = require('../db');
 
-  if (!(await db.isValidDatabase(target))) {
+  if (!force && !(await db.isValidDatabase(target))) {
     console.error(`${target} is not a valid database.`);
     return process.exit(2);
   }

--- a/src/cmd/url.js
+++ b/src/cmd/url.js
@@ -4,7 +4,7 @@ exports.desc = 'prints your current connection string';
 exports.builder = {};
 
 exports.handler = () => {
-  const db = require('../db');
+  const db = require('../db')();
   console.log(db.thisUrl());
   process.exit(0);
 };

--- a/src/db.js
+++ b/src/db.js
@@ -173,10 +173,13 @@ module.exports = (config = existingConfig) => {
   };
 
   return {
+    config,
+
     thisDb,
     thisUrl,
     fallbackUrl,
     combineUrl,
+    explodeUrl,
 
     getMigrationsPath,
 

--- a/src/db.js
+++ b/src/db.js
@@ -2,180 +2,190 @@ const knex = require('knex');
 const c = require('ansi-colors');
 const debug = require('debug')('pgsh:db');
 
-const config = require('./config');
+const existingConfig = require('./config');
+
 const updateExistingEnv = require('./env/update-existing');
 const findDir = require('./util/find-dir');
-
-const combineUrl = ({
-  user,
-  password,
-  host,
-  port,
-  database,
-}) =>
-  `postgres://${user}:${password}@${host}:${port}/${database}`;
 
 const REGEX_DATABASE_URL = new RegExp(
   '^postgres://([^:]+):([^@]+)@([^:]+):(\\d+)/(.+)$',
   'i',
 );
 
-const URL_MODE = config.mode === 'url';
-const testVar = URL_MODE ? config.vars.url : config.vars.database;
-
-if (!(testVar in process.env)) {
-  console.error(
-    `pgsh is configured to use the value of ${c.greenBright(testVar)}`
-      + ` in your ${c.underline('.env')} file, but it is unset. Exiting.`,
-  );
-  process.exit(6);
-}
-
-const DATABASE_URL = URL_MODE
-  ? process.env[config.vars.url]
-  : combineUrl({
-    user: process.env[config.vars.user],
-    password: process.env[config.vars.password],
-    host: process.env[config.vars.host],
-    port: process.env[config.vars.port],
-    database: process.env[config.vars.database],
-  });
-
-const explodeUrl = (databaseUrl) => {
-  const [
-    _full, // eslint-disable-line
-    user, password,
-    host, port, database,
-  ] = REGEX_DATABASE_URL.exec(databaseUrl);
-  return {
+module.exports = (config = existingConfig) => {
+  const combineUrl = ({
     user,
     password,
     host,
     port,
     database,
+  }) =>
+    `postgres://${user}:${password}@${host}:${port}/${database}`;
+
+  const URL_MODE = config.mode === 'url';
+  const testVar = URL_MODE ? config.vars.url : config.vars.database;
+
+  if (!(testVar in process.env)) {
+    console.error(
+      `pgsh is configured to use the value of ${c.greenBright(testVar)}`
+        + ` in your ${c.underline('.env')} file, but it is unset. Exiting.`,
+    );
+    process.exit(6);
+  }
+
+  const DATABASE_URL = URL_MODE
+    ? process.env[config.vars.url]
+    : combineUrl({
+      user: process.env[config.vars.user],
+      password: process.env[config.vars.password],
+      host: process.env[config.vars.host],
+      port: process.env[config.vars.port],
+      database: process.env[config.vars.database],
+    });
+
+  const explodeUrl = (databaseUrl) => {
+    const [
+      _full, // eslint-disable-line
+      user, password,
+      host, port, database,
+    ] = REGEX_DATABASE_URL.exec(databaseUrl);
+    return {
+      user,
+      password,
+      host,
+      port,
+      database,
+    };
   };
-};
 
-const thisDb = () =>
-  explodeUrl(DATABASE_URL).database;
+  const thisDb = () =>
+    explodeUrl(DATABASE_URL).database;
 
-const createSuperPostgresEnv = (databaseUrl = DATABASE_URL) => {
-  const {
-    user,
-    password,
-    host,
-    port,
-  } = explodeUrl(databaseUrl);
+  const createSuperPostgresEnv = (databaseUrl = DATABASE_URL) => {
+    const {
+      user,
+      password,
+      host,
+      port,
+    } = explodeUrl(databaseUrl);
+    return {
+      PGUSER: process.env[config.vars.super_user] || user,
+      PGPASSWORD: process.env[config.vars.super_password] || password,
+      PGHOST: host,
+      PGPORT: port,
+    };
+  };
+
+  const getMigrationsPath = () =>
+    findDir(
+      config.migrations.path || 'migrations',
+    ) || 'migrations';
+
+  const knexMigrationsOptions = () => {
+    const schema = config.migrations.schema || 'public';
+    const table = config.migrations.table || 'knex_migrations';
+    const migrations = { schemaName: schema, tableName: table };
+
+    const migrationsPath = getMigrationsPath();
+    if (migrationsPath) {
+      migrations.directory = migrationsPath;
+    }
+    return { migrations };
+  };
+
+  const connect = (databaseUrl = DATABASE_URL) =>
+    knex({
+      client: 'pg',
+      connection: explodeUrl(databaseUrl),
+      ...knexMigrationsOptions(),
+    });
+
+  const connectAsSuper = (databaseUrl = DATABASE_URL) => {
+    const connection = explodeUrl(databaseUrl);
+    if (config.vars.super_user) {
+      connection.user = process.env[config.vars.super_user];
+      connection.password = process.env[config.vars.super_password];
+    }
+    return knex({
+      client: 'pg',
+      connection,
+      ...knexMigrationsOptions(),
+    });
+  };
+
+  const modifyUrl = (modifications, databaseUrl = DATABASE_URL) =>
+    combineUrl({
+      ...explodeUrl(databaseUrl),
+      ...modifications,
+    });
+
+  /**
+   * Returns the connection string, optionally
+   * with a different database name at the end of it.
+   */
+  const thisUrl = database =>
+    (database
+      ? modifyUrl({ database }, DATABASE_URL)
+      : DATABASE_URL);
+
+  const fallbackUrl = () =>
+    thisUrl(config.fallback_database);
+
+  const databaseNames = async (showTemplates = false) => {
+    const getNames = (...connectionArgs) => {
+      const db = connectAsSuper(...connectionArgs);
+      return db.raw(`
+        SELECT datname
+        FROM pg_database
+        WHERE datistemplate = ?
+      `, [showTemplates])
+        .then(({ rows }) => rows.map(row => row.datname));
+    };
+
+    // first attempt to connect to the given database;
+    // if that does not work, fall back to the built-in "postgres"
+    try {
+      const names = await getNames();
+      return names;
+    } catch (err) {
+      const { message } = err;
+      debug(`databaseNames: ${c.redBright(message)}`);
+      debug(`databaseNames: using ${c.yellowBright(config.fallback_database)} instead`);
+      return getNames(thisUrl(config.fallback_database));
+    }
+  };
+
+  const isValidDatabase = async (name) => {
+    const names = await databaseNames();
+    return names.includes(name);
+  };
+
+  const switchTo = (database) => {
+    if (URL_MODE) {
+      updateExistingEnv({
+        [config.vars.url]: thisUrl(database),
+      }, { throwIfUnchanged: false });
+    } else {
+      updateExistingEnv({
+        [config.vars.database]: database,
+      }, { throwIfUnchanged: false });
+    }
+  };
+
   return {
-    PGUSER: process.env[config.vars.super_user] || user,
-    PGPASSWORD: process.env[config.vars.super_password] || password,
-    PGHOST: host,
-    PGPORT: port,
+    thisDb,
+    thisUrl,
+    fallbackUrl,
+    combineUrl,
+
+    getMigrationsPath,
+
+    connect,
+    connectAsSuper,
+    createSuperPostgresEnv,
+
+    databaseNames,
+    isValidDatabase,
+    switchTo,
   };
-};
-
-const getMigrationsPath = () =>
-  findDir(
-    config.migrations.path || 'migrations',
-  ) || 'migrations';
-
-const knexMigrationsOptions = () => {
-  const schema = config.migrations.schema || 'public';
-  const table = config.migrations.table || 'knex_migrations';
-  const migrations = { schemaName: schema, tableName: table };
-
-  const migrationsPath = getMigrationsPath();
-  if (migrationsPath) {
-    migrations.directory = migrationsPath;
-  }
-  return { migrations };
-};
-
-const connect = (databaseUrl = DATABASE_URL) =>
-  knex({
-    client: 'pg',
-    connection: explodeUrl(databaseUrl),
-    ...knexMigrationsOptions(),
-  });
-
-const connectAsSuper = (databaseUrl = DATABASE_URL) => {
-  const connection = explodeUrl(databaseUrl);
-  if (config.vars.super_user) {
-    connection.user = process.env[config.vars.super_user];
-    connection.password = process.env[config.vars.super_password];
-  }
-  return knex({
-    client: 'pg',
-    connection,
-    ...knexMigrationsOptions(),
-  });
-};
-
-const modifyUrl = (modifications, databaseUrl = DATABASE_URL) =>
-  combineUrl({
-    ...explodeUrl(databaseUrl),
-    ...modifications,
-  });
-
-/**
- * Returns the connection string, optionally
- * with a different database name at the end of it.
- */
-const thisUrl = database =>
-  (database
-    ? modifyUrl({ database }, DATABASE_URL)
-    : DATABASE_URL);
-
-const databaseNames = async () => {
-  const getNames = (...connectionArgs) => {
-    const db = connectAsSuper(...connectionArgs);
-    return db.raw(`
-      SELECT datname
-      FROM pg_database
-      WHERE datistemplate = false;
-    `).then(({ rows }) => rows.map(row => row.datname));
-  };
-
-  // first attempt to connect to the given database;
-  // if that does not work, fall back to the built-in "postgres"
-  try {
-    const names = await getNames();
-    return names;
-  } catch (err) {
-    const { message } = err;
-    debug(`databaseNames: ${c.redBright(message)}`);
-    debug(`databaseNames: using ${c.yellowBright(config.fallback_database)} instead`);
-    return getNames(thisUrl(config.fallback_database));
-  }
-};
-
-const isValidDatabase = async (name) => {
-  const names = await databaseNames();
-  return names.includes(name);
-};
-
-const switchTo = (database) => {
-  if (URL_MODE) {
-    updateExistingEnv({
-      [config.vars.url]: thisUrl(database),
-    });
-  } else {
-    updateExistingEnv({
-      [config.vars.database]: database,
-    });
-  }
-};
-
-module.exports = {
-  thisDb,
-  thisUrl,
-  getMigrationsPath,
-
-  connect,
-  connectAsSuper,
-  createSuperPostgresEnv,
-
-  databaseNames,
-  isValidDatabase,
-  switchTo,
 };

--- a/src/env/create.js
+++ b/src/env/create.js
@@ -26,7 +26,7 @@ module.exports = (keyValuePairs, encoding = 'utf8') => {
 
   fs.writeFileSync(
     createdPath,
-    fileContents,
+    `${fileContents}\n`,
     { encoding },
   );
 

--- a/src/pgshrc/create.js
+++ b/src/pgshrc/create.js
@@ -11,7 +11,7 @@ module.exports = (config) => {
   const configPath = path.join(envPath, '../.pgshrc');
   fs.writeFileSync(
     configPath,
-    JSON.stringify(config, null, 2),
+    `${JSON.stringify(config, null, 2)}\n`,
     { encoding: 'utf8' },
   );
   return configPath;

--- a/src/pgshrc/read.js
+++ b/src/pgshrc/read.js
@@ -7,7 +7,7 @@ const path = findConfig('.pgshrc');
 const defaultConfig = require('./default');
 
 const userConfig = path
-  ? JSON.parse(fs.readFileSync(path, { encoding: 'utf8' }))
+  ? JSON.parse(fs.readFileSync(path, 'utf8'))
   : null;
 
 const config = mergeOptions(defaultConfig, userConfig || {});

--- a/src/pgshrc/update-existing.js
+++ b/src/pgshrc/update-existing.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const debug = require('debug')('pgsh:update-existing');
+const deepEqual = require('deep-equal');
+const findConfig = require('find-config');
+const mergeOptions = require('merge-options');
+
+const configPath = findConfig('.pgshrc');
+
+/**
+ * Replace a value in the current .pgshrc, optionally
+ * throwing an error if nothing was changed.
+ */
+module.exports = (patch) => {
+  if (!configPath) {
+    throw new Error('Could not find .pgshrc file!');
+  }
+
+  const oldConfig = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  const newConfig = mergeOptions(oldConfig, patch);
+
+  if (deepEqual(oldConfig, newConfig, { strict: true })) {
+    debug('Nothing was changed in .pgshrc!');
+  }
+
+  fs.writeFileSync(
+    configPath,
+    `${JSON.stringify(newConfig, null, 2)}\n`,
+    { encoding: 'utf8' },
+  );
+};

--- a/src/task/choose-db.js
+++ b/src/task/choose-db.js
@@ -1,0 +1,127 @@
+const c = require('ansi-colors');
+const { prompt } = require('enquirer');
+
+const clone = require('./clone');
+const create = require('./create');
+const config = require('../config');
+
+const CHOICES = [
+  {
+    value: 'switch',
+    message: 'Connect to an existing database',
+  },
+  {
+    value: 'clone',
+    message: 'Clone an existing database',
+  },
+  {
+    value: 'create',
+    message: 'Create a new database',
+  },
+];
+
+const KEEP_CHOICE = {
+  value: 'keep',
+  message: 'Keep as-is',
+};
+
+const pick = async (db, message = 'Which database?', showTemplates = false) => {
+  const names = await db.databaseNames(showTemplates);
+  const { name } = await prompt({
+    type: 'select',
+    name: 'name',
+    message,
+    choices: names.sort(),
+  });
+  return name;
+};
+
+const dispatch = {
+  keep:
+    db => ({ database: db.thisDb() }),
+
+  switch:
+    async (db) => {
+      const database = await pick(db, 'Connect to which database?');
+      return { database };
+    },
+
+  clone:
+    async (db) => {
+      const { target } = await prompt({
+        type: 'input',
+        name: 'target',
+        message: 'What should the new database be called?',
+      });
+      const source = await pick(db, 'Which database do you want to clone?');
+
+      console.log();
+      console.log(
+        `Going to clone ${c.yellowBright(source)} to ${c.yellowBright(target)}...`,
+      );
+      await clone(db)(source, target);
+      console.log('Done!');
+
+      return { database: target };
+    },
+
+  create:
+    async (db) => {
+      const { pickTemplate } = await prompt({
+        type: 'toggle',
+        name: 'pickTemplate',
+        message:
+          `${c.bold('Do you need to change the template database?')}`
+            + ` (default ${c.yellowBright(config.template)})`,
+      });
+
+      const template = pickTemplate
+        ? await pick(db, 'Which template do you want to use?', true)
+        : config.template;
+
+      const { name } = await prompt({
+        type: 'input',
+        name: 'name',
+        message: 'What should the new database be called?',
+      });
+
+      console.log();
+      console.log(`Going to create ${c.yellowBright(name)}...`);
+      await create(db)(name, { template, switch: false });
+      console.log('Done!');
+
+      return {
+        database: name,
+        config: { template },
+      };
+    },
+};
+
+/**
+ * Pass in the current database value rather than get it from the config
+ * because we're probably in "knex init" and we don't have the env loaded.
+ *
+ * @returns { database, config } the database we've switched to and any config changes
+ */
+module.exports = db => async (currentDatabase) => {
+  if (currentDatabase) {
+    console.log(
+      `Your environment currently points to ${c.yellowBright(currentDatabase)}.`,
+    );
+    console.log();
+  }
+
+  const { mode } = await prompt(
+    {
+      name: 'mode',
+      type: 'select',
+      message: 'What would you like to do?',
+      choices: [
+        ...(currentDatabase ? [KEEP_CHOICE] : []),
+        ...CHOICES,
+      ],
+    },
+  );
+
+  return dispatch[mode](db);
+};

--- a/src/task/clone.js
+++ b/src/task/clone.js
@@ -1,0 +1,29 @@
+const { spawn } = require('child_process');
+
+const config = require('../config');
+
+module.exports = db => async (current, target) => {
+  const knex = db.connectAsSuper(db.fallbackUrl());
+  await knex.raw(`
+    create database "${target}"
+    template ${config.template || 'template1'}
+  `);
+
+  const p = spawn(
+    `pg_dump -Fc ${current} | pg_restore -d ${target}`,
+    {
+      shell: true,
+      env: db.createSuperPostgresEnv(),
+    },
+  );
+
+  return new Promise((resolve, reject) => {
+    p.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`psql failed (code ${code}, signal ${signal})`));
+      }
+    });
+  });
+};

--- a/src/task/clone.js
+++ b/src/task/clone.js
@@ -1,8 +1,9 @@
+const c = require('ansi-colors');
 const { spawn } = require('child_process');
 
-const config = require('../config');
-
 module.exports = db => async (current, target) => {
+  const { config } = db;
+
   const knex = db.connectAsSuper(db.fallbackUrl());
   await knex.raw(`
     create database "${target}"
@@ -17,12 +18,29 @@ module.exports = db => async (current, target) => {
     },
   );
 
+  // FIXME: capture stderr and pass to reject
+  p.stderr.on('data', e =>
+    process.stderr.write(c.redBright(e.toString())));
+
   return new Promise((resolve, reject) => {
     p.on('exit', (code, signal) => {
       if (code === 0) {
         resolve();
       } else {
-        reject(new Error(`psql failed (code ${code}, signal ${signal})`));
+        const superUser = process.env[config.vars.super_user];
+        if (!superUser) {
+          const currentUser = db.explodeUrl(db.thisUrl()).user;
+          reject(new Error(
+            'clone failed; this can happen if you do not have'
+              + ` the proper permissions on your user (${currentUser}).`
+              + ' Try configuring vars.super_[user|password] in your .pgshrc'
+              + ' to provide login information for commands that need it.',
+          ));
+        } else {
+          reject(new Error(
+            `psql failed (code ${code}, signal ${signal})`,
+          ));
+        }
       }
     });
   });

--- a/src/task/create.js
+++ b/src/task/create.js
@@ -1,0 +1,72 @@
+const c = require('ansi-colors');
+const { prompt } = require('enquirer');
+const mergeOptions = require('merge-options');
+
+const config = require('../config');
+const readMigrations = require('../util/read-migrations');
+
+const DEFAULT_OPTIONS = {
+  template: config.template || 'template1',
+  migrate: undefined,
+  yargs: undefined,
+  switch: true,
+};
+
+module.exports = db => async (name, options) => {
+  const opts = mergeOptions(DEFAULT_OPTIONS, options || {});
+
+  const current = db.thisUrl();
+  const knexFallback = db.connectAsSuper(db.fallbackUrl());
+  await knexFallback.raw(`
+    create database "${name}"
+    template ${opts.template}
+  `);
+  if (opts.switch) {
+    db.switchTo(name);
+    console.log(`Done! Switched to ${name}.`);
+  }
+
+  let shouldMigrate = false;
+  if (config.migrations && opts.migrate === undefined) {
+    // only show the prompt if we have some migrations in the folder.
+    const migrationFiles = readMigrations(db.getMigrationsPath());
+    if (migrationFiles.length > 0) {
+      shouldMigrate = (await prompt({
+        type: 'toggle',
+        name: 'migrate',
+        message: 'Migrate this database to the latest version?',
+      })).migrate;
+    }
+  }
+
+  if (config.migrations && shouldMigrate) {
+    const printLatest = require('../util/print-latest-migration')(opts.yargs);
+    try {
+      // TODO: DRY with "up" command
+      const knex = db.connect();
+      const [batch, filenames] = await knex.migrate.latest();
+      if (filenames.length > 0) {
+        console.log(`Migration batch #${batch} applied!`);
+        filenames.forEach(filename =>
+          console.log(`↑ ${c.yellowBright(filename)}`));
+        console.log();
+      }
+
+      await printLatest(knex);
+    } catch (err) {
+      console.error('Knex migration failed (see above).');
+      if (opts.switch) {
+        console.log(
+          `Switching back to ${c.yellowBright(current)}`
+          + ' and dropping the new database...',
+        );
+        db.switchTo(current);
+      }
+      await knexFallback.raw(`drop database "${name}"`);
+      console.log('Done.');
+      throw new Error('Migration failed; database dropped.');
+    }
+  }
+
+  return name;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,6 +375,11 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+deep-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"


### PR DESCRIPTION
* `pgsh switch -f` lets you switch to a database that doesn't exist
* files are now written with newlines at the end (i.e. `.env`, `.pgshrc`)
* `pgsh init` now asks you to choose a database whether or not you have an existing `.env`
* internally speaking...
   * `db` optionally takes `config` as an argument for easier bootstrapping
   * *clone* and *create* have been re-factored out as tasks
* error message improvements

Closes #24 
