### PR TITLE
Better flow for initialising without a .env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgsh",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Developer Tools for PostgreSQL",
   "main": "src/index.js",
   "repository": "git@github.com:sastraxi/pgsh.git",

--- a/src/cmd/init.js
+++ b/src/cmd/init.js
@@ -226,10 +226,6 @@ exports.handler = async () => {
         ? { url: buildUrl(userValues) }
         : userValues; // split mode can use values directly
 
-      console.log(userValues);
-      console.log('---');
-      console.log(env);
-
       // only create variables for env the user is interested in
       const vars = filterKeys(
         mode === 'url'

--- a/src/task/choose-db.js
+++ b/src/task/choose-db.js
@@ -48,12 +48,12 @@ const dispatch = {
 
   clone:
     async (db) => {
+      const source = await pick(db, 'Which database do you want to clone?');
       const { target } = await prompt({
         type: 'input',
         name: 'target',
         message: 'What should the new database be called?',
       });
-      const source = await pick(db, 'Which database do you want to clone?');
 
       console.log();
       console.log(

--- a/src/util/random-string.js
+++ b/src/util/random-string.js
@@ -1,0 +1,8 @@
+/* eslint-disable no-bitwise */
+
+// from https://gist.github.com/6174/6062387
+const randomString = (len = 16) =>
+  [...Array(len)].map(() =>
+    (~~(Math.random() * 36)).toString(36)).join('');
+
+module.exports = randomString;


### PR DESCRIPTION
* always use split mode to ask for inputs
* initially set the database to a long random string
* force a choice in `chooseDb` so that random string is never exposed to the user
* a better clone order of questions (source first, then target)

Closes #33 