### PR TITLE
Migration backends

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,8 +4,9 @@
     "no-console": "off",
     "implicit-arrow-linebreak": "off",
     "global-require": "off",
+    "no-multi-spaces": "off"
   },
   "env": {
     "jest": true
-  },
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,22 +16,22 @@
   "dependencies": {
     "ansi-colors": "^3.2.3",
     "backoff": "^2.5.0",
-    "bluebird": "^3.5.3",
+    "bluebird": "^3.7.1",
     "cli-table": "^0.3.1",
     "debug": "^4.1.1",
     "deep-equal": "^1.0.1",
-    "dotenv": "^6.2.0",
-    "enquirer": "^2.3.0",
+    "dotenv": "^8.2.0",
+    "enquirer": "^2.3.2",
     "find-config": "^1.0.0",
-    "knex": "^0.16.3",
+    "knex": "^0.20.2",
     "lodash.flattendeep": "^4.4.0",
     "lodash.pick": "^4.4.0",
     "merge-options": "^1.0.1",
     "moment": "^2.24.0",
-    "pg": "^7.8.0",
+    "pg": "^7.14.0",
     "pg-connection-string": "^0.1.3",
     "tmp": "^0.0.33",
-    "yargs": "^13.2.0"
+    "yargs": "^15.0.2"
   },
   "devDependencies": {
     "eslint": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgsh",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Developer Tools for PostgreSQL",
   "main": "src/index.js",
   "repository": "git@github.com:sastraxi/pgsh.git",

--- a/src/cmd/migrate/down.js
+++ b/src/cmd/migrate/down.js
@@ -1,0 +1,20 @@
+/* eslint-disable import/no-dynamic-require */
+const config = require('../../config');
+const delegate = require('./util/delegate');
+
+if (config.migrations.backend) {
+  const { backend } = config.migrations;
+  module.exports = require(`${backend}/down`);
+} else {
+  exports.command = 'down <ver>';
+  exports.desc = 'down-migrates the current database to the given migration';
+
+  exports.builder = yargs =>
+    yargs
+      .positional('ver', {
+        describe: 'the migration to migrate down to',
+        type: 'number',
+      });
+
+  exports.handler = delegate('down', { setConfig: true });
+}

--- a/src/cmd/migrate/down.js
+++ b/src/cmd/migrate/down.js
@@ -4,7 +4,7 @@ const delegate = require('./util/delegate');
 
 if (config.migrations.backend) {
   const { backend } = config.migrations;
-  module.exports = require(`${backend}/down`);
+  module.exports = require(`./${backend}/down`);
 } else {
   exports.command = 'down <ver>';
   exports.desc = 'down-migrates the current database to the given migration';

--- a/src/cmd/migrate/force-down.js
+++ b/src/cmd/migrate/force-down.js
@@ -1,0 +1,20 @@
+/* eslint-disable import/no-dynamic-require */
+const config = require('../../config');
+const delegate = require('./util/delegate');
+
+if (config.migrations.backend) {
+  const { backend } = config.migrations;
+  module.exports = require(`${backend}/force-down`);
+} else {
+  exports.command = 'force-down <ver>';
+  exports.desc = 'removes the record of any migration past the given version';
+
+  exports.builder = yargs =>
+    yargs
+      .positional('ver', {
+        describe: 'the migration number to migrate down to',
+        type: 'number',
+      });
+
+  exports.handler = delegate('force-down', { setConfig: true });
+}

--- a/src/cmd/migrate/force-down.js
+++ b/src/cmd/migrate/force-down.js
@@ -4,7 +4,7 @@ const delegate = require('./util/delegate');
 
 if (config.migrations.backend) {
   const { backend } = config.migrations;
-  module.exports = require(`${backend}/force-down`);
+  module.exports = require(`./${backend}/force-down`);
 } else {
   exports.command = 'force-down <ver>';
   exports.desc = 'removes the record of any migration past the given version';

--- a/src/cmd/migrate/force-up.js
+++ b/src/cmd/migrate/force-up.js
@@ -1,0 +1,13 @@
+/* eslint-disable import/no-dynamic-require */
+const config = require('../../config');
+const delegate = require('./util/delegate');
+
+if (config.migrations.backend) {
+  const { backend } = config.migrations;
+  module.exports = require(`${backend}/force-up`);
+} else {
+  exports.command = 'force-up';
+  exports.desc = 're-writes the migrations record entirely based on your migrations directory';
+  exports.builder = yargs => yargs;
+  exports.handler = delegate('force-up', { setConfig: true });
+}

--- a/src/cmd/migrate/force-up.js
+++ b/src/cmd/migrate/force-up.js
@@ -4,7 +4,7 @@ const delegate = require('./util/delegate');
 
 if (config.migrations.backend) {
   const { backend } = config.migrations;
-  module.exports = require(`${backend}/force-up`);
+  module.exports = require(`./${backend}/force-up`);
 } else {
   exports.command = 'force-up';
   exports.desc = 're-writes the migrations record entirely based on your migrations directory';

--- a/src/cmd/migrate/knex/detect.js
+++ b/src/cmd/migrate/knex/detect.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const debug = require('debug')('pgsh:detect');
+const findConfig = require('find-config');
+
+/**
+ * Quickly detect whether or not this project uses knex migrations.
+ * FIXME: right now, this simply detects if the project uses knex.
+ */
+module.exports = async () => {
+  if (findConfig('knexfile.js')) {
+    debug('found knexfile.js');
+    return true;
+  }
+  debug('could not find knexfile.js');
+
+  const packageJson = findConfig('package.json');
+  if (!packageJson) {
+    debug('could not find package.json');
+    return false;
+  }
+
+  const { dependencies, devDependencies } = JSON.parse(fs.readFileSync(packageJson, 'utf8'));
+  const foundVersion = dependencies.knex || devDependencies.knex;
+  debug(foundVersion ? `found knex:${foundVersion}` : 'could not find knex');
+  return !!foundVersion;
+};

--- a/src/cmd/migrate/knex/down.js
+++ b/src/cmd/migrate/knex/down.js
@@ -1,21 +1,21 @@
 const c = require('ansi-colors');
 const { spawn } = require('child_process');
-const readMigrations = require('../../util/read-migrations');
+const readMigrations = require('../../../util/read-migrations');
 
 exports.command = 'down <ver>';
-exports.desc = '(knex) down-migrates the current database to the given version. delegates to knex-migrate';
+exports.desc = '(knex) down-migrates the current database to the given migration. delegates to knex-migrate';
 
 exports.builder = yargs =>
   yargs
     .positional('ver', {
-      describe: 'the migration number to migrate down to',
+      describe: 'the migration to migrate down to',
       type: 'number',
     });
 
 exports.handler = async (yargs) => {
-  const db = require('../../db')();
-  const createKnexfile = require('../../util/create-knexfile')(db);
-  const printLatest = require('../../util/print-latest-migration')(db, yargs);
+  const db = require('../../../db')();
+  const createKnexfile = require('../../../util/create-knexfile')(db);
+  const printLatest = require('../../../util/print-latest-migration')(db, yargs);
 
   const { ver: version } = yargs;
 

--- a/src/cmd/migrate/knex/force-down.js
+++ b/src/cmd/migrate/knex/force-down.js
@@ -1,8 +1,8 @@
 const c = require('ansi-colors');
 const moment = require('moment');
 
-const confirm = require('../../util/confirm-prompt');
-const printTable = require('../../util/print-table');
+const confirm = require('../../../util/confirm-prompt');
+const printTable = require('../../../util/print-table');
 
 exports.command = 'force-down <ver>';
 exports.desc = 're-writes the `knex_migrations` table to not include the record of any migration past the given version.';
@@ -15,9 +15,9 @@ exports.builder = yargs =>
     });
 
 exports.handler = async (yargs) => {
-  const db = require('../../db')();
+  const db = require('../../../db')();
   const { ver: version, iso } = yargs;
-  const printLatest = require('../../util/print-latest-migration')(db, yargs);
+  const printLatest = require('../../../util/print-latest-migration')(db, yargs);
   const timestamp = raw => (iso
     ? moment(raw).format()
     : moment(raw).fromNow()

--- a/src/cmd/migrate/knex/force-up.js
+++ b/src/cmd/migrate/knex/force-up.js
@@ -1,7 +1,7 @@
 const c = require('ansi-colors');
 
-const confirm = require('../../util/confirm-prompt');
-const readMigrations = require('../../util/read-migrations');
+const confirm = require('../../../util/confirm-prompt');
+const readMigrations = require('../../../util/read-migrations');
 
 exports.command = 'force-up';
 exports.desc = 're-writes the knex migrations table entirely based on your migration directory';
@@ -9,8 +9,8 @@ exports.desc = 're-writes the knex migrations table entirely based on your migra
 exports.builder = {};
 
 exports.handler = async (yargs) => {
-  const db = require('../../db')();
-  const printLatest = require('../../util/print-latest-migration')(db, yargs);
+  const db = require('../../../db')();
+  const printLatest = require('../../../util/print-latest-migration')(db, yargs);
 
   const schema = db.config.migrations.schema || 'public';
   const table = db.config.migrations.table || 'knex_migrations';

--- a/src/cmd/migrate/knex/up.js
+++ b/src/cmd/migrate/knex/up.js
@@ -7,8 +7,8 @@ exports.desc = '(knex) migrates the current database to the latest version found
 exports.builder = yargs => yargs;
 
 exports.handler = async (yargs) => {
-  const db = require('../../db')();
-  const printLatest = require('../../util/print-latest-migration')(db, yargs);
+  const db = require('../../../db')();
+  const printLatest = require('../../../util/print-latest-migration')(db, yargs);
 
   try {
     const knex = db.connect();

--- a/src/cmd/migrate/knex/validate.js
+++ b/src/cmd/migrate/knex/validate.js
@@ -1,0 +1,60 @@
+const debug = require('debug')('pgsh:validate');
+const config = require('../../../config');
+const readMigrations = require('../../../util/read-migrations');
+
+exports.command = 'validate';
+exports.desc = '(knex) validates the current database against the migration directory';
+
+exports.builder = yargs => yargs;
+
+const getAppliedMigrations = async (knex) => {
+  const SCHEMA = config.migrations.schema || 'public';
+  const TABLE = config.migrations.table || 'knex_migrations';
+  try {
+    const filenames = await knex(`${SCHEMA}.${TABLE}`)
+      .orderBy('id', 'desc')
+      .select('name')
+      .map(r => r.name);
+
+    return filenames;
+  } catch (err) {
+    debug('could not list applied migrations', err);
+    return [];
+  }
+};
+
+exports.handler = async (yargs) => {
+  const db = require('../../../db')();
+  const printLatest = require('../../../util/print-latest-migration')(db, yargs);
+  try {
+    const knex = db.connect();
+    const migrationsPath = db.getMigrationsPath();
+    const applied = await getAppliedMigrations(knex);
+    const available = readMigrations(migrationsPath)
+      .map(m => m.name);
+
+    const missing = applied.filter(name => available.indexOf(name) === -1);
+    const unapplied = available.filter(name => applied.indexOf(name) === -1);
+
+    await printLatest();
+
+    if (!missing.length && !unapplied.length) {
+      process.exit(0);
+    }
+
+    if (missing.length) {
+      console.log(`The following applied migrations are missing from ${migrationsPath}`);
+      console.log(missing);
+    }
+
+    if (unapplied.length) {
+      console.log(`The following migrations in ${migrationsPath} have not been applied:`);
+      console.log(unapplied);
+    }
+
+    process.exit(1);
+  } catch (err) {
+    debug(err.message); // knex already prints out the error, so don't repeat unless we ask
+    process.exit(2);
+  }
+};

--- a/src/cmd/migrate/knex/validate.js
+++ b/src/cmd/migrate/knex/validate.js
@@ -1,3 +1,5 @@
+const c = require('ansi-colors');
+
 const debug = require('debug')('pgsh:validate');
 const config = require('../../../config');
 const readMigrations = require('../../../util/read-migrations');
@@ -33,8 +35,13 @@ exports.handler = async (yargs) => {
     const available = readMigrations(migrationsPath)
       .map(m => m.name);
 
-    const missing = applied.filter(name => available.indexOf(name) === -1);
-    const unapplied = available.filter(name => applied.indexOf(name) === -1);
+    const missing = applied
+      .filter(name => available.indexOf(name) === -1)
+      .map(c.redBright);
+
+    const unapplied = available
+      .filter(name => applied.indexOf(name) === -1)
+      .map(c.yellowBright);
 
     await printLatest();
 

--- a/src/cmd/migrate/up.js
+++ b/src/cmd/migrate/up.js
@@ -4,7 +4,7 @@ const delegate = require('./util/delegate');
 
 if (config.migrations.backend) {
   const { backend } = config.migrations;
-  module.exports = require(`${backend}/up`);
+  module.exports = require(`./${backend}/up`);
 } else {
   exports.command = 'up';
   exports.desc = 'migrates the current database to the latest version found in your migration directory';

--- a/src/cmd/migrate/up.js
+++ b/src/cmd/migrate/up.js
@@ -1,0 +1,13 @@
+/* eslint-disable import/no-dynamic-require */
+const config = require('../../config');
+const delegate = require('./util/delegate');
+
+if (config.migrations.backend) {
+  const { backend } = config.migrations;
+  module.exports = require(`${backend}/up`);
+} else {
+  exports.command = 'up';
+  exports.desc = 'migrates the current database to the latest version found in your migration directory';
+  exports.builder = yargs => yargs;
+  exports.handler = delegate('up', { setConfig: true });
+}

--- a/src/cmd/migrate/util/delegate.js
+++ b/src/cmd/migrate/util/delegate.js
@@ -1,0 +1,24 @@
+/* eslint-disable import/no-dynamic-require */
+const detect = require('./detect');
+const updateConfig = require('../../../pgshrc/update-existing');
+
+const DEFAULT_OPTIONS = {
+  setConfig: false,
+};
+
+module.exports = (command, { setConfig } = DEFAULT_OPTIONS) => async (yargs) => {
+  const backend = await detect();
+  if (!backend) {
+    console.log('Could not detect a migrations backend! Exiting.');
+    return process.exit(1);
+  }
+
+  if (setConfig) {
+    updateConfig({
+      migrations: { backend },
+    });
+  }
+
+  const { handler } = require(`../${backend}/${command}`);
+  return handler(yargs);
+};

--- a/src/cmd/migrate/util/delegate.js
+++ b/src/cmd/migrate/util/delegate.js
@@ -6,7 +6,11 @@ const DEFAULT_OPTIONS = {
   setConfig: false,
 };
 
-module.exports = (command, { setConfig } = DEFAULT_OPTIONS) => async (yargs) => {
+/**
+ * Returns a yargs handler that tries to figure out which backend to run,
+ * sets it in .pgshrc, then delegates to an existing command's handler.
+ */
+const delegate = (command, { setConfig } = DEFAULT_OPTIONS) => async (yargs) => {
   const backend = await detect();
   if (!backend) {
     console.log('Could not detect a migrations backend! Exiting.');
@@ -22,3 +26,5 @@ module.exports = (command, { setConfig } = DEFAULT_OPTIONS) => async (yargs) => 
   const { handler } = require(`../${backend}/${command}`);
   return handler(yargs);
 };
+
+module.exports = delegate;

--- a/src/cmd/migrate/util/detect.js
+++ b/src/cmd/migrate/util/detect.js
@@ -1,0 +1,6 @@
+const knex = require('../knex/detect');
+
+module.exports = async () => {
+  if (await knex()) return 'knex';
+  return undefined;
+};

--- a/src/cmd/migrate/validate.js
+++ b/src/cmd/migrate/validate.js
@@ -1,0 +1,13 @@
+/* eslint-disable import/no-dynamic-require */
+const config = require('../../config');
+const delegate = require('./util/delegate');
+
+if (config.migrations.backend) {
+  const { backend } = config.migrations;
+  module.exports = require(`${backend}/validate`);
+} else {
+  exports.command = 'validate';
+  exports.desc = 'validates the current database against the migration directory';
+  exports.builder = yargs => yargs;
+  exports.handler = delegate('validate', { setConfig: true });
+}

--- a/src/cmd/migrate/validate.js
+++ b/src/cmd/migrate/validate.js
@@ -4,7 +4,7 @@ const delegate = require('./util/delegate');
 
 if (config.migrations.backend) {
   const { backend } = config.migrations;
-  module.exports = require(`${backend}/validate`);
+  module.exports = require(`./${backend}/validate`);
 } else {
   exports.command = 'validate';
   exports.desc = 'validates the current database against the migration directory';

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,8 @@ require('yargs')
     default: false,
     describe: 'introspect databases and show their latest migrations',
   })
-  .commandDir('cmd', { recurse: true })
+  .commandDir('cmd', { recurse: false })
+  .commandDir('cmd/migrate', { recurse: false })
   .command(
     '$0',
     'prints all databases',

--- a/src/pgshrc/default.js
+++ b/src/pgshrc/default.js
@@ -15,10 +15,11 @@ module.exports = {
     /* super_user: 'PG_SUPER_USER', */
     /* super_password: 'PG_SUPER_PASSWORD', */
   },
-  migrations: { /* passed to knex */
-    path: 'migrations',
-    schema: 'public',
-    table: 'knex_migrations',
+  migrations: {
+    backend: undefined,       /* needs to be detected; no default */
+    path: 'migrations',       /* knex */
+    schema: 'public',         /* knex */
+    table: 'knex_migrations', /* knex */
   },
   protected: ['master'], /* don't destroy these branches */
   /* by default filter: is undefined; default "pgsh list" prefix */

--- a/src/util/read-migrations.js
+++ b/src/util/read-migrations.js
@@ -16,7 +16,7 @@ module.exports = (migrationsPath) => {
     if (!match) {
       return console.warn(`Skipping non-migration ${filename}`);
     }
-    const [_full, zeroes, textualNumber] = match; // eslint-disable-line
+    const [_full, zeroes, textualNumber] = match; // eslint-disable-line no-unused-vars
     return {
       id: +textualNumber,
       name: filename,


### PR DESCRIPTION
So far, no new migration backends, just moving knex over to a "plugin-based" system.

* a new command has been added, `pgsh validate`, to show differences between your migration files (in source control) and the ones that have been applied to the database.

Closes #43. Closes #18 as well