### PR TITLE
Enhance the clone command

### DIFF
--- a/src/cmd/clone.js
+++ b/src/cmd/clone.js
@@ -1,34 +1,97 @@
 const c = require('ansi-colors');
 
-exports.command = 'clone <target>';
-exports.desc = 'clones your current database as target, then switches to it';
+const confirm = require('../util/confirm-prompt');
+const waitFor = require('../util/wait-for');
+
+// N.B. yargs didn't work so well when this was [source] <target>,
+// so we have to account for the 1-argument version in our handler.
+exports.command = 'clone [source] [target]';
+exports.desc = 'clones a database, then (potentially) switches to it';
 
 exports.builder = yargs => yargs
-  .positional('target', {
-    describe: 'the name to give the cloned database',
+  .positional('source', {
+    describe: 'the database to clone (defaults to the current database)',
     type: 'string',
-  });
+  })
+  .positional('target', {
+    describe: 'the name to give the cloned database (required!)',
+    type: 'string',
+    required: true,
+    default: undefined,
+  })
+  .option('f', {
+    alias: 'force',
+    type: 'boolean',
+    describe: 'do not warn before overwriting an existing database (use with caution!)',
+    default: false,
+  })
+  .option('s', {
+    alias: 'switch',
+    type: 'boolean',
+    describe: 'switch to the newly-created database (by default true when cloning the current db)',
+  })
+  .option('S', {
+    type: 'boolean',
+    describe: 'do not switch to the newly-created database',
+  })
+  .conflicts('s', 'S')
+  .conflicts('S', 's');
 
-exports.handler = async ({ target }) => {
+exports.handler = async ({
+  source: argSource,
+  target: argTarget,
+  force,
+  s, // -s, --switch
+  S, // -S, --no-switch
+}) => {
   const db = require('../db')();
   const clone = require('../task/clone')(db);
 
-  const current = db.thisDb();
-  if (target === current) {
+  // account for the 1-argument version (target only).
+  const currentDb = db.thisDb();
+  const oneArg = !argTarget;
+  const source = oneArg ? currentDb : argSource;
+  const target = oneArg ? argSource : argTarget;
+
+  if (target === source) {
     console.log(`Cannot clone to ${target}; that's the current database!`);
     return process.exit(1);
   }
 
-  if (await db.isValidDatabase(target)) {
-    console.error(`Cannot clone to ${target}; that database already exists!`);
-    return process.exit(2);
+  const targetExists = await db.isValidDatabase(target);
+  if (targetExists && !force) {
+    const interruptHandler = () => {
+      console.log(`\nDid not drop ${target}!`);
+      return process.exit(0);
+    };
+
+    console.error(`The ${target} database already exists.`);
+    try {
+      await confirm('Type the database name to drop it: ', target);
+      await waitFor(db, target, interruptHandler);
+      const knex = db.connectAsSuper(db.fallbackUrl());
+      await knex.raw(`drop database "${target}"`);
+    } catch (err) {
+      console.log('Not dropping.');
+      return process.exit(0);
+    }
   }
 
-  console.log(`Going to clone ${current} to ${target}...`);
+  /* eslint-disable max-len */
+  let shouldSwitch = (source === currentDb);  // by default, only switch if we're cloning the current db
+  if (s !== undefined) shouldSwitch = s;      // user has explicitly decided via -s, --switch
+  if (S !== undefined) shouldSwitch = !S;     // user has explicitly decided via -S, --no-switch
+  /* eslint-enable max-len */
+
+  console.log(`Going to clone ${source} to ${target}...`);
   try {
-    await clone(current, target);
-    db.switchTo(target);
-    console.log(`Done! Switched to ${target}.`);
+    await clone(source, target);
+    if (shouldSwitch) {
+      db.switchTo(target);
+      console.log(`Done! Switched to ${target}.`);
+    } else {
+      console.log(`Done! Created ${target}.`);
+    }
     return process.exit(0);
   } catch (err) {
     console.error(

--- a/src/util/wait-for.js
+++ b/src/util/wait-for.js
@@ -7,7 +7,7 @@ const fibonacciBackoff = backoff.fibonacci({
   maxDelay: 12000,
 });
 
-const waitFor = (db, target, interruptHandler, failFast) =>
+const waitFor = (db, target, interruptHandler, failFast = false) =>
   new Promise(async (resolve) => {
     const connectionCount = connectionCountTask(db);
     const otherConnections = await connectionCount(target);


### PR DESCRIPTION
The new version of the clone command can:

* clone a database other than the current one: `pgsh clone <source> <target>`
* drop databases that already exist (uses confirm prompt or you can `-f` or `--force`)
* keep you on the same database (`--no-switch` or `-S`), or forefully switch (`--switch` or `-s`).

The default switching behaviour is based on the `source`: if it's the current database, by default we'll switch to the newly-created database.

Closes #40