### PR TITLE
Allow users to pgsh create without switching

### DIFF
--- a/src/cmd/create.js
+++ b/src/cmd/create.js
@@ -13,9 +13,21 @@ exports.builder = yargs => yargs
     type: 'boolean',
     describe: 'also migrate the new database to the current version',
     default: undefined,
+  })
+  .option('S', {
+    alias: 'no-switch',
+    type: 'boolean',
+    describe: 'do not switch to the newly-created database',
+    default: undefined,
   });
 
-exports.handler = async ({ name, migrate, ...yargs }) => {
+exports.handler = async ({
+  name,
+  migrate,
+  switch: shouldSwitch, // --no-switch
+  S: dontSwitch,        // -S
+  ...yargs
+}) => {
   const db = require('../db')();
   const create = require('../task/create')(db);
 
@@ -35,7 +47,7 @@ exports.handler = async ({ name, migrate, ...yargs }) => {
     await create(name, {
       migrate,
       yargs,
-      switch: true,
+      switch: shouldSwitch !== undefined ? shouldSwitch : !dontSwitch, // TODO: coalesce
     });
 
     return process.exit(0);

--- a/src/cmd/destroy.js
+++ b/src/cmd/destroy.js
@@ -1,3 +1,5 @@
+const c = require('ansi-colors');
+
 const confirm = require('../util/confirm-prompt');
 const waitFor = require('../util/wait-for');
 
@@ -47,7 +49,7 @@ exports.handler = async ({ target, failFast }) => {
 
   try {
     await waitFor(db, target, interruptHandler, failFast);
-    await confirm('Type the database name to drop it: ', target);
+    await confirm(c.redBright('Type the database name to drop it: '), target);
     await waitFor(db, target, interruptHandler, failFast);
   } catch (err) {
     console.log('Not dropping.');

--- a/src/cmd/list.js
+++ b/src/cmd/list.js
@@ -6,7 +6,7 @@ const config = require('../config');
 
 const printTable = require('../util/print-table');
 
-exports.command = 'list [prefix]';
+exports.command = ['list [prefix]', 'ls', 'l'];
 exports.desc = 'prints all databases, filtered by an optional prefix';
 
 exports.builder = yargs => yargs
@@ -46,7 +46,8 @@ const migrationOutput = async (knex, isPrimary) => {
 
 exports.handler = async (yargs) => {
   const db = require('../db')();
-  const { prefix, verbose, created } = yargs;
+  const { prefix, verbose: explictlyVerbose, created } = yargs;
+  const showMigrations = explictlyVerbose !== undefined ? explictlyVerbose : !!db.config.migrations;
 
   try {
     const current = db.thisDb();
@@ -62,7 +63,7 @@ exports.handler = async (yargs) => {
 
       async (name) => {
         let migration = [];
-        if (config.migrations && verbose) {
+        if (showMigrations) {
           const knex = db.connectAsSuper(db.thisUrl(name));
           migration = await migrationOutput(knex, name === current);
         }

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,10 @@ require('dotenv').config({
   encoding: config.dotenv_encoding || 'utf8',
 });
 
-const list = require('./cmd/list');
-
 // eslint-disable-next-line no-unused-expressions
 require('yargs')
   .scriptName('pgsh')
-  .usage('pgsh: developer tools for interacting with postgresql databases')
+  .usage('pgsh: developer tools for interacting with postgres databases')
   .option('i', {
     alias: 'iso',
     type: 'boolean',
@@ -20,17 +18,12 @@ require('yargs')
   .option('verbose', {
     alias: 'a',
     type: 'boolean',
-    default: false,
+    default: undefined,
     describe: 'introspect databases and show their latest migrations',
   })
   .commandDir('cmd', { recurse: false })
   .commandDir('cmd/migrate', { recurse: false })
-  .command(
-    '$0',
-    'prints all databases',
-    list.builder,
-    list.handler,
-  )
+  .recommendCommands()
   .demandCommand()
   .help()
   .epilogue('See https://github.com/sastraxi/pgsh for more information')

--- a/src/task/create.js
+++ b/src/task/create.js
@@ -25,6 +25,8 @@ module.exports = (db) => {
     if (opts.switch) {
       db.switchTo(name);
       console.log(`Done! Switched to ${name}.`);
+    } else {
+      console.log(`Done! created ${name}.`);
     }
 
     let shouldMigrate = false;

--- a/src/util/wait-for.js
+++ b/src/util/wait-for.js
@@ -7,6 +7,14 @@ const fibonacciBackoff = backoff.fibonacci({
   maxDelay: 12000,
 });
 
+/**
+ * Waits until no other sessions are accessing the given database.
+ *
+ * @param {*} db a Database connection
+ * @param {*} target the name of the database to monitor
+ * @param {*} interruptHandler if we need to abandon waiting for any reason, call this
+ * @param {*} failFast give up immediately if the database is not available
+ */
 const waitFor = (db, target, interruptHandler, failFast = false) =>
   new Promise(async (resolve) => {
     const connectionCount = connectionCountTask(db);
@@ -27,7 +35,9 @@ const waitFor = (db, target, interruptHandler, failFast = false) =>
     }
 
     const readyHandler = async () => {
-      if (await connectionCount(target) > 0) {
+      const count = await connectionCount(target);
+      if (count > 0) {
+        console.log(`${count}...`);
         fibonacciBackoff.backoff();
       } else {
         process.removeListener('SIGINT', interruptHandler);


### PR DESCRIPTION
Also a couple unrelated things tonight:

* there is no default command anymore
* `pgsh l` and `pgsh ls` are now aliases for `pgsh list`
* `-a|--verbose` is now undefined by default (and resolves to true if you have migrations enabled in `.pgshrc`!)
* fix counting the number of users connecting to a database
* create now takes `-S` and `--no-switch` options