### PR TITLE
Bump pg from 7.14.0 to 8.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lodash.pick": "^4.4.0",
     "merge-options": "^2.0.0",
     "moment": "^2.24.0",
-    "pg": "^7.14.0",
+    "pg": "^8.5.1",
     "pg-connection-string": "^2.1.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.8",


### PR DESCRIPTION
I was required to bump pg to get pgsh running with node 14.